### PR TITLE
Initial Scanner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .venv/
-
+C:\Year Two\Projects\ParserPDF\__pycache__
+__pycache__
 __pycache__/
+.vscode/

--- a/app.py
+++ b/app.py
@@ -1,12 +1,14 @@
 import json
 import re
 import datetime
-from flask import Flask, render_template, request, send_file
+from flask import Flask, abort, render_template, request, send_file
 
 from coursePlanner import initData
-from exportToCalendar import exportToIcal
+from exportToCalendar import exportToIcal, addEventsToCalWithOnlyDates
 
 from extractRooms import getRooms, filterByBuilding, scoreRoomsGivenTime, scoreRoomsCurrTime, sortRooms, get_day_abbrev
+
+from courseOutlineParser import courseOutlineParser
 
 app = Flask(__name__)
 
@@ -137,4 +139,22 @@ def finder():
         displayWeekday = get_day_abbrev(datetime.datetime.now().weekday())
     return render_template("finder.html", htmlRooms=htmlRooms,building=building, displayTime=displayTime, displayWeekday=displayWeekday)
 
+app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024  #Safety limit files 16mb
+@app.route("/outlineParser", methods=["GET", "POST"])
+def outlineParser():
+    if request.method == "POST":
+        print("Request received")
+        courseCodes = request.form.getlist("courseCode")
+        files = request.files.getlist("outlinePDF")
+        courses: list[courseOutlineParser] = []
 
+        for courseCode, file in zip(courseCodes, files): # add robust way to check against malicious file upload, curently using html
+            groups = courseOutlineParser(file, courseCode).parseKeyDateGroups()
+            courses.append(groups)
+        
+        addEventsToCalWithOnlyDates(courses)
+        print("Courses processed and calendar exported.")
+
+        return send_file("courseImportantDates.ics", as_attachment=True)
+
+    return render_template("outlineParser.html")

--- a/courseOutlineParser.py
+++ b/courseOutlineParser.py
@@ -1,0 +1,158 @@
+import pdfplumber
+import re
+import dateparser
+from icalendar import Calendar, Event
+from datetime import datetime, timedelta
+
+# specific regex patterns for data in text
+MONTHS = (
+    r"january|february|march|april|may|june|july|august|september|october|november|december|"
+    r"jan.|feb.|mar.|apr.|may.|jun.|jul.|aug.|sep.|oct.|nov.|dec."
+    r"jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec"
+)
+
+ASSIGNMENT_KEYWORDS = (
+    r"assignment|homework|project|paper|presentation|report|essay|lab\s+test"
+)
+TEST_KEYWORDS = (
+    r"test|exam|midterm|evalutations|assessment|final"
+)
+QUIZ_KEYWORDS = (
+    r"quiz|zybook"
+)
+
+#Excclude admistrative dates so misclassifcation doesnt arrise
+ADMIN_KEYWORDS = [
+    "classes",
+    "lectures",
+    "class",
+    "first day",
+    "last day",
+    "thanksgiving",
+    "study day",
+    "drop",
+    "fall break",
+    "spring break",
+    "winter break",
+    "summer break",
+    "winter session",
+    "summer session",
+    "winter term",
+    "summer term",
+    "winter semester",
+    "summer semester",
+]
+
+# regex matching 
+month_name_pattern = re.compile(
+                    r"""#start of line
+                    \b(""" + MONTHS + r""") #month names, \b ensures you dont get enmarching match
+                    \s+  #Spaces, unlimted spaces 
+                    (\d{1,2}) #day 
+                    (?:st|nd|rd|th)? #optional suffix ending bc andrew hamilton-wright keeps writing 1st :c
+                    (?:,?\s*(\d{4}))? #optional comma or space followed by year
+                    \b #end of line"""
+                    , re.IGNORECASE | re.VERBOSE)
+
+assignment_pattern = re.compile(
+    rf"""\b({ASSIGNMENT_KEYWORDS}|a\d{{1,2}})\b""",
+    re.IGNORECASE | re.VERBOSE
+)
+
+# class to parse course outline
+class courseOutlineParser:
+    def __init__(self, outline: str, courseCode: str):
+        """
+        Stores key dates. General approach predict based on last classifer found
+
+        self.classifier: Keeps track of last listed keyword type (assignment, test, quiz)
+                         All lines are classified as such until new keyword found
+                         Works relatively well for tables? may not generalize to all outlines
+        """
+        self.outline = outline
+        self.courseCode = courseCode
+        self.testDates = [] # list of test dates
+        self.assignmentDates = [] # list of assignment dates
+        self.quizDates = [] # list of quiz dates
+        self.classifier = "" 
+
+    def parseKeyDateGroups(self):
+        """
+        Parses data from course outline PDF and classifies them into groups
+
+        Utilizes last encountered classifier to classify lines of pdf text.
+        Assumption is made that lines with dates are test/quiz/assignment dates, 
+        admin keywords are used to filter out non relevant lines
+        """
+        with pdfplumber.open(self.outline) as pdf:
+            for page in pdf.pages: 
+                # Iterate over each line in text converted pdf
+                for line in (page.extract_text() or "").split("\n"):
+                    line = line.lower()
+                    if any(keyword in line for keyword in ADMIN_KEYWORDS):
+                        continue
+
+                    if assignment_pattern.search(line):
+                        self.classifier = "assignment"
+                    elif re.search(QUIZ_KEYWORDS, line):
+                        self.classifier = "quiz"
+                    elif re.search(TEST_KEYWORDS, line):
+                        self.classifier = "test"
+
+                    if month_name_pattern.search(line):
+                        if self.classifier == "test":
+                            self.testDates.append(line)
+                        elif self.classifier == "assignment":
+                            self.assignmentDates.append(line)
+                        elif self.classifier == "quiz":
+                            self.quizDates.append(line)
+        #         # im = page.to_image(resolution=150)
+        #         # im.show()
+
+        pdf.close()
+        return self
+
+    def formatDates(self, newCalendar: Calendar):
+        for test in self.testDates:
+            newCalendar.add_component(self.addToCalendar(test, f"{self.courseCode} - Test: {test}"))
+
+        for assignment in self.assignmentDates: 
+            newCalendar.add_component(self.addToCalendar(assignment, f"{self.courseCode} - Assignment: {assignment}"))
+
+        for i,quiz in enumerate(self.quizDates):
+            newCalendar.add_component(self.addToCalendar(quiz, f"{self.courseCode} - Quiz: {quiz}"))
+        
+        return newCalendar
+
+    def addToCalendar(self, item: str, description: str) -> Event: 
+        # TO-DO: update description to not include time component
+
+        event = Event()
+
+        match = month_name_pattern.search(item)
+        if not match:
+            print("No date found in item: ", item)
+            return event
+        
+        dateStr = match.group(0)
+        date = dateparser.parse(dateStr)
+
+        descriptionWithoutDate = re.sub(re.escape(dateStr), "", description, flags=re.IGNORECASE).strip()
+        
+        if date is None:
+            print("Could not parse extracted date: ", dateStr)
+            return event
+        
+        try:
+            event.add('summary', descriptionWithoutDate)
+            start = date.date()
+            end = start + timedelta(days = 1) # make event last all day long 
+            event.add('dtstart', start)
+            event.add('dtend', end)
+
+            # print("Added event: ", descriptionWithoutDate, " on ", start)
+        except:
+            print("invalid date parsing for item: ", item, "\n", date,start,end, "\n")
+
+
+        return event

--- a/exportToCalendar.py
+++ b/exportToCalendar.py
@@ -2,6 +2,8 @@ from icalendar import Calendar, Event, vDatetime
 from datetime import datetime
 import zoneinfo
 
+from courseOutlineParser import courseOutlineParser
+
 #Code from https://github.com/AlphaCloudX/Schedule-Optimizer
 
 def exportToIcal(courses, allCourseData):
@@ -60,3 +62,13 @@ def getFirstDay(day):
     else:
         print("getFirstDay(): invaild weekday")
         return 0
+    
+def addEventsToCalWithOnlyDates(courses: list[courseOutlineParser]):
+    newCal = Calendar()
+    for course in courses:
+        course.formatDates(newCal)
+
+    newIcs = open("courseImportantDates.ics", 'wb+')
+    newIcs.write(newCal.to_ical())
+    print("Calendar exported.")
+    newIcs.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask>=2.0.0
+icalendar>=5.0.0
+pdfplumber>=0.9.0
+dateparser>=1.0.0

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,7 @@
             <h1>Course Schedule to .ics W25</h1>
             <a href="/">ScheduleToICS</a>
             <a href="/finder">Study Spot Finder</a>
+            <a href="/outlineParser">Test and Quiz Date Extractor (experimental)</a>
             <h3>Enter courses seperated with commas or spaces</h3>
             <h4>EG: CIS*2250*0103 CIS*2500*0102 MATH*1160*01 ANTH*1150*DE01 MCS*1000*0103</h4>
             

--- a/templates/outlineParser.html
+++ b/templates/outlineParser.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title> Test/Quiz Date Extractor (experimental)</title>
+    <link rel="stylesheet" href="../static/style.css">
+</head>
+<body>
+
+    <div style="text-align: center">
+        <h1>Test and Quiz Date Extractor (experimental)</h1>
+        <a href="/">Home</a>
+        <a href="/finder">Study Spot Finder</a>
+        <a href="/outlineParser">Test and Quiz Date Extractor (experimental)</a>
+        <p>Upload course outlines to extract test and quiz dates</p>
+    </div>
+
+    <form action="/outlineParser" method="post" enctype="multipart/form-data" id="outlineFiles">
+        <div id="classes-container">
+             <!-- user prompted courses entered, maybe make it auto sync with courses added from main page with cookie-->
+        </div>
+        
+        <button type="button" id="add-class-btn">Add New Class</button>
+        <br>
+        <button type="submit" id="submit-btn">Submit All</button>
+    </form>
+
+    <!-- add class entries as user requests -->
+    <script>
+        let classCounter = 0;
+
+        function addClassEntry() {
+            classCounter++;
+            const container = document.getElementById('classes-container');
+            const classEntry = document.createElement('div');
+            classEntry.className = 'class-entry';
+            classEntry.id = `class-${classCounter}`;
+            
+            classEntry.innerHTML = `
+                <label>Course Code:</label>
+                <input type="text" name="courseCode" placeholder="e.g., CIS*2250" required>
+                <label>Choose File:</label>
+                <input type="file" name="outlinePDF" accept=".pdf" required>
+                <button type="button" class="remove-btn" onclick="removeClassEntry('class-${classCounter}')">Remove</button>
+            `;
+            
+            container.appendChild(classEntry);
+        }
+
+        function removeClassEntry(classId) {
+            const element = document.getElementById(classId);
+            if (element) {
+                element.remove();
+            }
+        }
+
+        // Add first class entry on page load
+        document.addEventListener('DOMContentLoaded', function() { addClassEntry(); });
+
+        // Add class entry when button is clicked
+        document.getElementById('add-class-btn').addEventListener('click', addClassEntry);
+    </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
Created Initial PDF parser for course outline, adding Summative dates to Google Calendar 

## Changes
- Added `gitignore` : No more pushing pycache please 
- Modified `app.py` : added api endpoint for Parser() 
- Added `courseOutlineParser.py`: Utilizes regex search to find key test/assignment/lab/quiz dates
- Modified `exportToCalendar.py` : Tried to follow alphacloud convention, added function to create ICS calendar without start/end dates 
- Added `requirements.txt` : Use a virtual environment please 
- Modified `templates/index.html.` : added sublink to test/assignment/lab/quiz dates extractor 
- Added `templates/outlineParser.html` : New HTML file + scripting to add course content

## Motivation / Context
Thought it would be useful to have summative dates automatically generated bc im a bit lazy 

## How to Test
Steps someone can follow to verify the changes (windows):

1. Checkout this branch
2. Create virtual environment `python -m venv venv`
3. Activate virtual enviornment `venv\scripts\activate\`
4. Run `flask --app app --debug run`
5. Observe expected behavior

## Notes
This is a bit flawed, I'd say I'm about 60% sure its working 90% correctly? Problems and next steps include
- Differentiating between start/end dates when present in same line of text (if regex approach is kept)
- Creating more strict checking mechanisms to detect assignment vs tests vs etc.
- Finding some way to validate summative assessments as hallucinatory assignments sometimes appear
- Styling (my eyes hurt) 

## Disclaimer 
This is not functioning perfectly, and I do not pretend it is. I think its useful as a starter for your schedule / mindfulness tool, so thats why im posting it. I'll follow up with more changes to improve the classification accuracy when I have some more free time.